### PR TITLE
speedup with pmin and do.call ref #20

### DIFF
--- a/R/get_dist.R
+++ b/R/get_dist.R
@@ -10,7 +10,7 @@
     }
     res <- sapply(target_idx, .cal_dist, poss = poss)
     if (get_min) {
-        return(apply(res, 1, min) + count_from)
+        return(do.call(pmin, as.data.frame(res)) + count_from)
     }
     return(res)
 }


### PR DESCRIPTION
``` r
m <- matrix(sample(1:20,20000,replace=TRUE),ncol=5)
bench::mark(
    apply = apply(m, 1, min),
    pmin = do.call(pmin, as.data.frame(m))
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 apply        2.68ms   2.82ms      347.     156KB     30.3
#> 2 pmin       129.33µs 133.66µs     7027.     253KB     21.1
```

<sup>Created on 2023-11-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

this is probably as good as it gets